### PR TITLE
Refactor export logic: convert query strings to subdirectories for st…

### DIFF
--- a/src/Traits/NormalizedPath.php
+++ b/src/Traits/NormalizedPath.php
@@ -20,11 +20,16 @@ trait NormalizedPath
 
     protected function sanitizePathForFilesystem(string $path): string
     {
-        // Characters that are problematic in filesystem paths
+        // If there's a query string, convert it into a subdirectory
+        if (strpos($path, '?') !== false) {
+            $parts = explode('?', $path, 2);
+            $basePath = $parts[0];
+            $query = $parts[1];
+            // Do not encode '=' or '&', just append as subdirectory
+            $path = rtrim($basePath, '/') . '/' . $query;
+        }
+        // Encode other problematic characters except '=' and '&' in the query string
         $problematicChars = [
-            '?' => '%3F',
-            '=' => '%3D',
-            '&' => '%26',
             ':' => '%3A',
             '<' => '%3C',
             '>' => '%3E',
@@ -33,7 +38,6 @@ trait NormalizedPath
             '*' => '%2A',
             // Don't encode forward slashes as they're path separators
         ];
-
         return str_replace(array_keys($problematicChars), array_values($problematicChars), $path);
     }
 }

--- a/tests/ExportTest.php
+++ b/tests/ExportTest.php
@@ -154,25 +154,29 @@ it('exports paths with query parameters', function () {
     });
     Route::redirect('redirect', 'https://spatie.be');
 
+    $paths = [
+        '/',                      // Required by afterEach
+        '/about',                 // Required by afterEach
+        '/feed/blog.atom',        // Required by afterEach
+        '/redirect',              // Required by afterEach
+    ];
+
+    // Add test-categories with page query from 1 to 7
+    $maxPage = 7;
+    foreach (range(1, $maxPage) as $page) {
+        $paths[] = "/test-categories?page={$page}";
+    }
+
     app(Exporter::class)
         ->crawl(false)
-        ->paths([
-            '/',                      // Required by afterEach
-            '/about',                 // Required by afterEach
-            '/feed/blog.atom',        // Required by afterEach
-            '/redirect',              // Required by afterEach
-            '/test-categories?page=1',
-            '/test-categories?page=2',
-        ])
+        ->paths($paths)
         ->export();
 
-    // Check if files are created with URL-encoded names
-    $expectedPath1 = __DIR__.'/dist/test-categories%3Fpage%3D1/index.html';
-    $expectedPath2 = __DIR__.'/dist/test-categories%3Fpage%3D2/index.html';
-    expect(file_exists($expectedPath1))->toBeTrue("Expected file not found: {$expectedPath1}");
-    expect(file_exists($expectedPath2))->toBeTrue("Expected file not found: {$expectedPath2}");
-    // dd($expectedPath1, $expectedPath2);
-    // Verify content is correct
-    expect(file_get_contents($expectedPath1))->toBe('Test Categories page 1');
-    expect(file_get_contents($expectedPath2))->toBe('Test Categories page 2');
+    // Check if files are created and content is correct for each page
+    foreach (range(1, $maxPage) as $page) {
+        $expectedPath = __DIR__."/dist/test-categories/page={$page}/index.html";
+        expect(file_exists($expectedPath))->toBeTrue("Expected file not found: {$expectedPath}");
+        expect(file_get_contents($expectedPath))->toBe("Test Categories page {$page}");
+    }
 });
+


### PR DESCRIPTION
…atic export

- Updated NormalizedPath to convert URLs with query strings into subdirectories (e.g., /test-categories?page=2 → /test-categories/page=2/index.html).
- Do not encode '=' or '&' in query strings; instead, use them as directory names.
- Updated ExportTest to verify that all requested pages are exported as subdirectories and their content matches.
- This change allows Apache and other static servers to serve the correct file using default .htaccess rules.